### PR TITLE
Small cleanup and remove duplicate check

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,20 +17,20 @@ You'll want to create a schema first. Schemas are JSON-ish documents that look s
 ```js
 {
     // Comments are allowed, as are unquoted keys
-    
+
     // The simplest types are just a string because they need no config
     Field : "text",
-    
+
     // More complicated types always have at least a "type" property, and depending
     // on what they are will use a few more
-    
+
     // instructions types have one of a head or body, or both.
-	Start : {
+    Start : {
         type : "instructions",
         head : "This is a content type",
         body : "Here is what you do with it, hello"
     },
-    
+
     // Fieldsets are a direct mapping to <fieldset>
     Schedule : {
         type : "fieldset",
@@ -39,7 +39,7 @@ You'll want to create a schema first. Schemas are JSON-ish documents that look s
                 type : "instructions",
                 body : "Enter schedule information for this thing"
             },
-            
+
             // Repeating fields allow for multiple data points to be added
             Repeating : {
                 type : "repeating",
@@ -51,7 +51,20 @@ You'll want to create a schema first. Schemas are JSON-ish documents that look s
     },
     Text : "text",
     Number : "number",
-    
+
+    // Split fields
+    split : {
+        type : "split",
+        sections : {
+            left : {
+                location : "text"
+            },
+            right : {
+                rank : "text"
+            }
+        }
+    },
+
     // Tabbed fields
     tabs : {
         type : "tabs",
@@ -60,13 +73,13 @@ You'll want to create a schema first. Schemas are JSON-ish documents that look s
                 "Title" : "text",
                 "Body" : "text"
             },
-			
-			DE : {
+
+            DE : {
                 "Title" : "text"
             }
         }
     },
-    
+
     // <select> analogue, showing both short hand <option> values as well as
     // making one option selected by default
     "Make your choice" : {

--- a/index.html
+++ b/index.html
@@ -3,11 +3,11 @@
 <head>
     <meta charset="utf8" />
     <title>Crucible</title>
-    
+
     <link rel="stylesheet" type="text/css" href="/node_modules/purecss/build/pure.css">
     <link rel="stylesheet" type="text/css" href="/node_modules/codemirror/lib/codemirror.css">
     <link rel="stylesheet" type="text/css" href="/gen/index.css">
-    
+
     <script src="/config.js"></script>
     <script src="/gen/index.js" async></script>
 </head>

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var m = require("mithril"),
-    
+
     auth = require("./lib/require-auth");
 
 m.route.mode = "pathname";
@@ -9,7 +9,7 @@ m.route.mode = "pathname";
 exports.default = function() {
     m.route(document.body, "/", {
         "/" : auth(require("./pages/home")),
-        
+
         "/login"  : require("./pages/login"),
         "/logout" : require("./pages/logout"),
 
@@ -18,7 +18,7 @@ exports.default = function() {
         "/content/:schema"      : auth(require("./pages/content")),
         "/content/:schema/edit" : auth(require("./pages/schema-edit")),
         "/content/:schema/:id"  : auth(require("./pages/content-edit")),
-        
+
         "/content/:schema/:id/history"          : auth(require("./pages/content-history")),
         "/content/:schema/:id/history/:version" : auth(require("./pages/content-history-view"))
     });

--- a/src/types/_input.js
+++ b/src/types/_input.js
@@ -2,7 +2,6 @@
 
 var m      = require("mithril"),
     assign = require("lodash.assign"),
-    slug   = require("sluggo"),
 
     update  = require("../lib/update"),
     id      = require("../lib/id"),
@@ -12,14 +11,14 @@ module.exports = function(type) {
     return {
         controller : function(options) {
             var ctrl = this;
-            
+
             ctrl.id = id(options)
         },
 
         view : function(ctrl, options) {
             var details = options.details,
                 name    = details.name;
-            
+
             if(details.required) {
                 name += "*";
             }

--- a/src/types/children.js
+++ b/src/types/children.js
@@ -6,7 +6,7 @@ var m      = require("mithril"),
 
     input = require("./_input"),
 
-    css  = require("./types.css"),
+    css = require("./types.css"),
 
     // Bound below
     types;
@@ -19,22 +19,22 @@ module.exports = {
             details.map(function(field, index) {
                 var component = types[field.type || field],
                     data, ref;
-                
+
                 if(!component) {
                     return m("div",
                         m("p", "Unknown component"),
                         m("pre", JSON.stringify(field, null, 4))
                     );
                 }
-                
+
                 if(component.decorative) {
                     data = options.data;
-                    ref  = options.ref && options.ref;
+                    ref  = options.ref;
                 } else {
                     data = get(options, "data." + field.slug);
                     ref  = options.ref && options.ref.child(field.slug);
                 }
-                
+
                 return m.component(component, assign({}, options, {
                     details : field,
                     class   : css[index ? "field" : "first"],
@@ -49,17 +49,17 @@ module.exports = {
 // Have to bind these down here to avoid circular binding issues
 types = {
     // Structural
-    fieldset : require("./fieldset"),
+    fieldset  : require("./fieldset"),
     repeating : require("./repeating"),
-    split : require("./split"),
-    tabs : require("./tabs"),
+    split     : require("./split"),
+    tabs      : require("./tabs"),
 
     // Non-input fields
     instructions : require("./instructions"),
     relationship : require("./relationship"),
     select       : require("./select"),
     textarea     : require("./textarea"),
-    
+
     // These are all just variations on the input type
     date     : input("date"),
     datetime : input("datetime-local"),

--- a/src/types/fieldset.js
+++ b/src/types/fieldset.js
@@ -2,13 +2,13 @@
 
 var m      = require("mithril"),
     assign = require("lodash.assign"),
-    
+
     children = require("./children");
 
 module.exports = {
     // Ignore this component in the data hierarchy
     decorative : true,
-    
+
     view : function(ctrl, options) {
         return m("fieldset", { class : options.class },
             options.details.name ? m("legend", options.details.name) : null,

--- a/src/types/instructions.js
+++ b/src/types/instructions.js
@@ -1,14 +1,14 @@
 "use strict";
 
 var m = require("mithril"),
-    
+
     types = require("./types.css"),
     css   = require("./instructions.css");
 
 module.exports = {
     view : function(ctrl, options) {
         var details = options.details;
-        
+
         return m("div", { class : options.class },
             details.head ? m("p", { class : css.head }, details.head) : null,
             details.body ? m("p", details.body) : null

--- a/src/types/relationship.js
+++ b/src/types/relationship.js
@@ -4,11 +4,10 @@ var m      = require("mithril"),
     assign = require("lodash.assign"),
     map    = require("lodash.map"),
     fuzzy  = require("fuzzysearch"),
-    slug   = require("sluggo"),
-    
+
     db = require("../lib/firebase"),
     id = require("../lib/id"),
-    
+
     types = require("./types.css"),
     css   = require("./relationship.css");
 
@@ -18,7 +17,7 @@ module.exports = {
             schema  = options.details.schema,
             content = db.child("content/" + schema),
             sources;
-        
+
         ctrl.id = id(options);
 
         ctrl.sources = function() {
@@ -60,7 +59,7 @@ module.exports = {
         // Set up a two-way relationship between these
         ctrl.add = function(id) {
             options.ref.child(id).set(true);
-            
+
             content.child(id + "/relationships/" + options.root.key()).set(true);
         };
 
@@ -71,15 +70,15 @@ module.exports = {
             content.child(id + "/relationships/" + options.root.key()).remove();
         };
     },
-    
+
     view : function(ctrl, options) {
         var details = options.details,
             name    = details.name;
-            
+
         if(details.required) {
             name += "*";
         }
-        
+
         return m("div", { class : options.class },
             m("ul",
                 options.data && Object.keys(options.data).map(function(key) {

--- a/src/types/repeating.js
+++ b/src/types/repeating.js
@@ -3,7 +3,7 @@
 var m      = require("mithril"),
     assign = require("lodash.assign"),
     times  = require("lodash.times"),
-    
+
     children     = require("./children"),
     instructions = require("./instructions"),
 
@@ -41,7 +41,7 @@ module.exports = {
             if(!options.ref) {
                 return;
             }
-    
+
             // Ensure that we have data placeholders for all the possible entries
             times(ctrl.children, function(idx) {
                 if(options.data && options.data[idx]) {
@@ -51,7 +51,7 @@ module.exports = {
                 options.ref.child(idx).set("placeholder");
             });
         };
-        
+
         ctrl.remove = function(options, data, idx, e) {
             // No ref means we don't much care
             if(!options.ref || !options.data) {

--- a/src/types/select.js
+++ b/src/types/select.js
@@ -2,7 +2,6 @@
 
 var m      = require("mithril"),
     assign = require("lodash.assign"),
-    slug   = require("sluggo"),
 
     id = require("../lib/id"),
 
@@ -15,36 +14,36 @@ function optvalue(option) {
 module.exports = {
     controller : function(options) {
         var ctrl = this;
-        
+
         ctrl.id = id(options);
 
         ctrl.onchange = function(options, index) {
             var opt = options.details.children[index];
-            
+
             options.ref.set(optvalue(opt));
         };
     },
-    
+
     view : function(ctrl, options) {
         var details = options.details,
             value   = options.data,
             name    = details.name;
-            
+
         if(details.required) {
             name += "*";
         }
-        
+
         // Need to go see if one of the options should be already selected
         if(!value) {
             details.children.some(function(opt) {
                 if(opt.selected) {
                     value = optvalue(opt);
                 }
-                
+
                 return value;
             });
         }
-        
+
         return m("div", { class : options.class },
             m("label", {
                 for   : ctrl.id,

--- a/src/types/split.js
+++ b/src/types/split.js
@@ -2,7 +2,7 @@
 
 var m      = require("mithril"),
     assign = require("lodash.assign"),
-    
+
     children     = require("./children"),
     instructions = require("./instructions"),
     css          = require("./split.css");
@@ -10,10 +10,10 @@ var m      = require("mithril"),
 module.exports = {
     // Ignore this component in the data hierarchy
     decorative : true,
-    
+
     view : function(ctrl, options) {
         var details = options.details;
-        
+
         return m("div", { class : css.container },
             details.instructions ? m.component(instructions, { details : details.instructions }) : null,
             (details.children || []).map(function(section) {

--- a/src/types/tabs.js
+++ b/src/types/tabs.js
@@ -2,7 +2,7 @@
 
 var m      = require("mithril"),
     assign = require("lodash.assign"),
-    
+
     children = require("./children"),
 
     css = require("./tabs.css");
@@ -10,12 +10,12 @@ var m      = require("mithril"),
 module.exports = {
     controller : function() {
         var ctrl = this;
-        
+
         ctrl.tab = 0;
 
         ctrl.switchtab = function(tab, e) {
             e.preventDefault();
-            
+
             ctrl.tab = tab;
         };
     },

--- a/src/types/textarea.js
+++ b/src/types/textarea.js
@@ -2,7 +2,6 @@
 
 var m      = require("mithril"),
     assign = require("lodash.assign"),
-    slug   = require("sluggo"),
 
     update  = require("../lib/update"),
     id      = require("../lib/id"),
@@ -12,7 +11,7 @@ var m      = require("mithril"),
 module.exports = {
     controller : function(options) {
         var ctrl = this;
-    
+
         ctrl.id   = id(options);
         ctrl.text = options.data || "";
 
@@ -28,7 +27,7 @@ module.exports = {
     view : function(ctrl, options) {
         var details = options.details,
             name    = details.name;
-        
+
         if(details.required) {
             name += "*";
         }

--- a/src/workers/save-schema.js
+++ b/src/workers/save-schema.js
@@ -38,7 +38,7 @@ function process(obj) {
                     children : process(tab)
                 };
             });
-            
+
             delete field.tabs;
         }
 
@@ -67,7 +67,7 @@ function process(obj) {
 
             delete field.options;
         }
-        
+
         if(field.type === "split") {
             field.children = Object.keys(field.sections).map(function(name) {
                 return {
@@ -76,7 +76,7 @@ function process(obj) {
                     children : process(field.sections[name])
                 };
             });
-            
+
             delete field.sections;
         }
 


### PR DESCRIPTION
Added an example of `split` to the README schema. Removed unused `sluggo` `requires` in `src` types. No check and assign in `children` type. And some habitual whitespace cleanup.