### PR TITLE
Tidied up page titles

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "firebase": "^2.3.2",
     "fuzzysearch": "^1.0.3",
     "lodash.assign": "^4.0.0",
+    "lodash.capitalize": "^4.0.1",
     "lodash.debounce": "^4.0.0",
     "lodash.get": "^4.0.0",
     "lodash.map": "^4.0.0",

--- a/src/lib/capitalize.js
+++ b/src/lib/capitalize.js
@@ -1,5 +1,0 @@
-"use strict";
-
-module.exports = function(s) {
-    return (s && s.length) ? s.charAt(0).toUpperCase() + s.slice(1) : null;
-};

--- a/src/lib/capitalize.js
+++ b/src/lib/capitalize.js
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = function(s) {
+    return (s && s.length) ? s.charAt(0).toUpperCase() + s.slice(1) : null;
+};

--- a/src/pages/content-edit.js
+++ b/src/pages/content-edit.js
@@ -11,6 +11,8 @@ var m      = require("mithril"),
     update   = require("../lib/update"),
     watch    = require("../lib/watch"),
 
+    capitalize = require("../lib/capitalize"),
+
     layout = require("./layout"),
     nav    = require("./content-edit/nav"),
 
@@ -26,7 +28,7 @@ module.exports = {
             id     = m.route.param("id"),
             schema = db.child("schemas/" + m.route.param("schema")),
             ref    = db.child("content/" + m.route.param("schema") + "/" + id);
-        
+
         ctrl.id     = id;
         ctrl.ref    = ref;
         ctrl.data   = null;
@@ -40,23 +42,23 @@ module.exports = {
 
             m.redraw();
         });
-        
+
         // No sense doing any work if we don't have an id to operate on
         if(!id) {
             return;
         }
-        
+
         // On updates from firebase we need to merge in fields carefully
         ref.on("value", function(snap) {
             var data = snap.val();
-            
+
             ctrl.data = assign(data, {
                 fields : merge(data.fields, ctrl.data.fields)
             });
 
             m.redraw();
         });
-        
+
         watch(ref);
     },
 
@@ -64,9 +66,9 @@ module.exports = {
         if(!ctrl.schema) {
             return m.component(layout);
         }
-        
+
         return m.component(layout, {
-            title : get(ctrl.data, "name"),
+            title : capitalize(get(ctrl.data, "name")) + " | " + capitalize(ctrl.schema.name),
 
             nav : m.component(nav, { schema : ctrl.schema }),
 

--- a/src/pages/content-edit.js
+++ b/src/pages/content-edit.js
@@ -11,7 +11,7 @@ var m      = require("mithril"),
     update   = require("../lib/update"),
     watch    = require("../lib/watch"),
 
-    capitalize = require("../lib/capitalize"),
+    capitalize = require("lodash.capitalize"),
 
     layout = require("./layout"),
     nav    = require("./content-edit/nav"),

--- a/src/pages/content-edit.js
+++ b/src/pages/content-edit.js
@@ -1,17 +1,16 @@
 "use strict";
 
-var m      = require("mithril"),
-    get    = require("lodash.get"),
-    set    = require("lodash.set"),
-    merge  = require("lodash.merge"),
-    assign = require("lodash.assign"),
+var m          = require("mithril"),
+    get        = require("lodash.get"),
+    set        = require("lodash.set"),
+    merge      = require("lodash.merge"),
+    assign     = require("lodash.assign"),
+    capitalize = require("lodash.capitalize"),
 
     children = require("../types/children"),
     db       = require("../lib/firebase"),
     update   = require("../lib/update"),
     watch    = require("../lib/watch"),
-
-    capitalize = require("lodash.capitalize"),
 
     layout = require("./layout"),
     nav    = require("./content-edit/nav"),

--- a/src/pages/content-edit/nav.js
+++ b/src/pages/content-edit/nav.js
@@ -11,6 +11,8 @@ var m        = require("mithril"),
     db     = require("../../lib/firebase"),
     remove = require("../../lib/remove"),
 
+    capitalize = require("../../lib/capitalize"),
+
     css = require("./nav.css"),
 
     size = 30;
@@ -104,6 +106,10 @@ module.exports = {
     view : function(ctrl) {
         var pages = [],
             current;
+
+        if(!m.route.param("id")) {
+            document.title = capitalize(ctrl.schema.name);
+        }
 
         if(ctrl.results) {
             current = {

--- a/src/pages/content-edit/nav.js
+++ b/src/pages/content-edit/nav.js
@@ -1,17 +1,16 @@
 "use strict";
 
-var m        = require("mithril"),
-    paginate = require("paginationator"),
-    moment   = require("moment"),
-    fuzzy    = require("fuzzysearch"),
-    debounce = require("lodash.debounce"),
-    get      = require("lodash.get"),
-    slug     = require("sluggo"),
+var m          = require("mithril"),
+    paginate   = require("paginationator"),
+    moment     = require("moment"),
+    fuzzy      = require("fuzzysearch"),
+    debounce   = require("lodash.debounce"),
+    get        = require("lodash.get"),
+    capitalize = require("lodash.capitalize"),
+    slug       = require("sluggo"),
 
     db     = require("../../lib/firebase"),
     remove = require("../../lib/remove"),
-
-    capitalize = require("lodash.capitalize"),
 
     css = require("./nav.css"),
 

--- a/src/pages/content-edit/nav.js
+++ b/src/pages/content-edit/nav.js
@@ -11,7 +11,7 @@ var m        = require("mithril"),
     db     = require("../../lib/firebase"),
     remove = require("../../lib/remove"),
 
-    capitalize = require("../../lib/capitalize"),
+    capitalize = require("lodash.capitalize"),
 
     css = require("./nav.css"),
 

--- a/src/pages/content-history-view.js
+++ b/src/pages/content-history-view.js
@@ -1,11 +1,10 @@
 "use strict";
 
-var m = require("mithril"),
+var m          = require("mithril"),
+    capitalize = require("lodash.capitalize"),
 
     children = require("../types/children"),
     db       = require("../lib/firebase"),
-
-    capitalize = require("lodash.capitalize"),
 
     layout = require("./layout"),
 

--- a/src/pages/content-history-view.js
+++ b/src/pages/content-history-view.js
@@ -4,9 +4,11 @@ var m = require("mithril"),
 
     children = require("../types/children"),
     db       = require("../lib/firebase"),
-    
+
+    capitalize = require("../lib/capitalize"),
+
     layout = require("./layout"),
-    
+
     css = require("./content-edit.css");
 
 module.exports = {
@@ -17,7 +19,7 @@ module.exports = {
             version = m.route.param("version"),
 
             ref;
-        
+
         ctrl.data   = null;
         ctrl.schema = null;
 
@@ -36,7 +38,7 @@ module.exports = {
 
             m.redraw();
         });
-        
+
         db.child("schemas/" + schema).on("value", function(snap) {
             ctrl.schema = snap.val();
 
@@ -50,7 +52,7 @@ module.exports = {
         }
 
         return m.component(layout, {
-            title   : ctrl.data.name,
+            title   : capitalize(ctrl.data.name),
             content : [
                 m("h1", { class : css.heading },
                     m("span", { class : css.schema }, ctrl.schema.name, m.trust("&nbsp;/&nbsp;")),

--- a/src/pages/content-history-view.js
+++ b/src/pages/content-history-view.js
@@ -5,7 +5,7 @@ var m = require("mithril"),
     children = require("../types/children"),
     db       = require("../lib/firebase"),
 
-    capitalize = require("../lib/capitalize"),
+    capitalize = require("lodash.capitalize"),
 
     layout = require("./layout"),
 

--- a/src/pages/content-history.js
+++ b/src/pages/content-history.js
@@ -5,7 +5,7 @@ var m      = require("mithril"),
 
     db = require("../lib/firebase"),
 
-    capitalize = require("../lib/capitalize"),
+    capitalize = require("lodash.capitalize"),
 
     layout = require("./layout"),
     css    = require("./content-history.css");

--- a/src/pages/content-history.js
+++ b/src/pages/content-history.js
@@ -5,6 +5,8 @@ var m      = require("mithril"),
 
     db = require("../lib/firebase"),
 
+    capitalize = require("../lib/capitalize"),
+
     layout = require("./layout"),
     css    = require("./content-history.css");
 
@@ -79,7 +81,7 @@ module.exports = {
         }
 
         return m.component(layout, {
-            title   : ctrl.versions[0].name,
+            title   : capitalize(ctrl.versions[0].name),
             content : m("div",
                 m("h1", "History for: " + ctrl.versions[0].name),
                 m("table", { class : css.table },

--- a/src/pages/content-history.js
+++ b/src/pages/content-history.js
@@ -1,11 +1,10 @@
 "use strict";
 
-var m      = require("mithril"),
-    moment = require("moment"),
+var m          = require("mithril"),
+    moment     = require("moment"),
+    capitalize = require("lodash.capitalize"),
 
     db = require("../lib/firebase"),
-
-    capitalize = require("lodash.capitalize"),
 
     layout = require("./layout"),
     css    = require("./content-history.css");

--- a/src/pages/layout/index.js
+++ b/src/pages/layout/index.js
@@ -62,14 +62,14 @@ module.exports = {
                         m("div", { class : nav.schemas },
                             (ctrl.schemas || []).map(function(schema) {
                                 var url = "/content/" + schema.key;
-                                
+
                                 return m("div", { class : nav[route.indexOf(url) === 0 ? "active" : "schema"] },
                                     m("a", {
                                         class  : nav.link,
                                         href   : url,
                                         config : m.route
                                     }, schema.name),
-                                    
+
                                     m("a", {
                                             class  : nav.edit,
                                             title  : "Edit Schema",

--- a/src/pages/schema-edit.js
+++ b/src/pages/schema-edit.js
@@ -8,7 +8,9 @@ var m        = require("mithril"),
     watch  = require("../lib/watch"),
     db     = require("../lib/firebase"),
     update = require("../lib/update"),
-    
+
+    capitalize = require("../lib/capitalize"),
+
     editor = require("./schema-edit/editor"),
 
     layout = require("./layout"),
@@ -19,7 +21,7 @@ module.exports = {
         var ctrl = this,
             id   = m.route.param("schema"),
             ref  = db.child("schemas/" + id);
-            
+
         ctrl.ref     = ref;
         ctrl.schema  = null;
         ctrl.data    = {};
@@ -31,24 +33,24 @@ module.exports = {
         // Get Firebase data
         ref.on("value", function(snap) {
             ctrl.schema = snap.val();
-            
+
             if(!ctrl.preview.value) {
                 ctrl.preview.value = ctrl.schema.preview || "";
             }
 
             m.redraw();
         });
-        
+
         // Event Handlers
         ctrl.previewChanged = function(e) {
             var el = e.target;
 
             ctrl.preview.valid = el.validity.valid;
             ctrl.preview.value = el.value;
-            
+
             ref.child("preview").set(el.value);
         };
-        
+
         watch(ref);
     },
 
@@ -56,9 +58,9 @@ module.exports = {
         if(!ctrl.schema) {
             return m.component(layout);
         }
-        
+
         return m.component(layout, {
-            title   : "Edit - " + ctrl.schema.name,
+            title   : "Edit - " + capitalize(ctrl.schema.name),
             content : [
                 m(".body", { class : css.body },
                         m("div", { class : css.meta },

--- a/src/pages/schema-edit.js
+++ b/src/pages/schema-edit.js
@@ -1,15 +1,14 @@
 "use strict";
 
-var m        = require("mithril"),
-    debounce = require("lodash.debounce"),
+var m          = require("mithril"),
+    debounce   = require("lodash.debounce"),
+    capitalize = require("lodash.capitalize"),
 
     children = require("../types/children"),
 
     watch  = require("../lib/watch"),
     db     = require("../lib/firebase"),
     update = require("../lib/update"),
-
-    capitalize = require("lodash.capitalize"),
 
     editor = require("./schema-edit/editor"),
 

--- a/src/pages/schema-edit.js
+++ b/src/pages/schema-edit.js
@@ -9,7 +9,7 @@ var m        = require("mithril"),
     db     = require("../lib/firebase"),
     update = require("../lib/update"),
 
-    capitalize = require("../lib/capitalize"),
+    capitalize = require("lodash.capitalize"),
 
     editor = require("./schema-edit/editor"),
 


### PR DESCRIPTION
Capitalization and formatting of content title ([name] | [type]) can be dropped if preferred.

Fixes #50.