### PR TITLE
JWT auth support

### DIFF
--- a/src/pages/login.js
+++ b/src/pages/login.js
@@ -9,9 +9,34 @@ var m = require("mithril"),
     layout = require("./layout"),
     css    = require("./login.css");
 
+function loginRedirect() {
+    window.location = global.crucible.loginBaseUrl + window.encodeURIComponent(window.location.origin + "/login");
+}
+
 module.exports = {
     controller : function() {
         var ctrl = this;
+
+        if(global.crucible.auth === "jwt") {
+            m.startComputation();
+
+            if(!m.route.param("auth")) {
+                return loginRedirect();
+            }
+
+            db.authWithCustomToken(m.route.param("auth"), function(error) {
+                if(error) {
+                    loginRedirect();
+
+                    return;
+                }
+
+                m.endComputation();
+                m.route(route.path("/"));
+            });
+
+            return;
+        }
         
         if(!global.crucible.auth || valid()) {
             return m.route(route.path("/"));


### PR DESCRIPTION
Adds support for json web token logins to firebase.  Set "auth" in config to "jwt", and also provide a loginBaseUrl in config for where to send the user for logins.