### PR TITLE
Default publish time option

### DIFF
--- a/src/pages/content-edit/head.js
+++ b/src/pages/content-edit/head.js
@@ -2,7 +2,7 @@
 
 var m      = require("mithril"),
     moment = require("moment"),
-    set    = require("lodash.set"),
+    get    = require("lodash.get"),
     upper  = require("lodash.capitalize"),
 
     db = require("../../lib/firebase"),
@@ -34,10 +34,10 @@ module.exports = {
         } else {
             ctrl.start = {
                 date : "",
-                time : ""
+                time : get(global.crucible, "defaults.publish_start_time") || ""
             };
         }
-
+        
         if(unpublish) {
             ctrl.end = {
                 date   : unpublish.format("YYYY-MM-DD"),


### PR DESCRIPTION
Fixes #85

Adds a new concept, the `defaults` object within the config. For now only supports the `publish_start_time` key.

```js
var crucible = {
    firebase : "...",
    defaults : {
        publish_start_time : "09:00"
    }
};
```