### PR TITLE
Add error bar to schema editor

### DIFF
--- a/src/pages/layout/layout.css
+++ b/src/pages/layout/layout.css
@@ -32,6 +32,8 @@
 
 .content {
     composes: section, padding;
+    
+    position: relative;
 }
 
 .head {

--- a/src/pages/schema-edit.css
+++ b/src/pages/schema-edit.css
@@ -42,6 +42,19 @@
     padding: 0 10px 10px 10px;
 }
 
+.error {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    
+    margin: 0;
+    padding: 5px;
+    
+    background: red;
+    color: whitesmoke;
+}
+
 /* Override codemirror styling to make it expannnnd */
 :global(.CodeMirror) {
     height: 100% !important;

--- a/src/pages/schema-edit/editor.js
+++ b/src/pages/schema-edit/editor.js
@@ -14,10 +14,7 @@ require("codemirror/addon/comment/continuecomment");
 
 module.exports = {
     controller : function(options) {
-        var ctrl = this,
-            
-            // Weird path is because this isn't browserified
-            parse = new Worker("./parse.js");
+        var ctrl = this;
         
         // Set up codemirror
         ctrl.editorSetup = function(el, init) {
@@ -61,14 +58,9 @@ module.exports = {
 
                 options.ref.child("source").set(text);
                 
-                parse.postMessage(text);
+                options.worker.postMessage(text);
             }, 500, { maxWait : 5000 }));
         };
-
-        // Listen for the worker to finish and update firebase
-        parse.addEventListener("message", function(e) {
-            options.ref.child("fields").set(e.data);
-        });
     },
     
     view : function(ctrl, options) {

--- a/src/pages/schema-edit/parse.js
+++ b/src/pages/schema-edit/parse.js
@@ -107,12 +107,10 @@ self.onmessage = function(e) {
     try {
         // This is super-gross but in a worker should be (mostly) safe
         eval("config = " + e.data);
-        parsed = process(config)
+        parsed = process(config);
         
-        self.postMessage(parsed);
+        return self.postMessage(parsed);
     } catch(error) {
-        console.error("Invalid config", error);
-        
-        return;
+        return self.postMessage(error.toString());
     }
 };


### PR DESCRIPTION
It can't show much useful information due to how browsers handle `eval`, sadly. At least it's something to let you know you screwed up.

Also if there is already some schema text we process it ASAP instead of waiting for an editor update event.

Fixes #86 