### PR TITLE
Upload widget

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "lodash.assign": "^4.0.0",
     "lodash.capitalize": "^4.0.1",
     "lodash.debounce": "^4.0.0",
+    "lodash.filter": "^4.2.1",
     "lodash.get": "^4.0.0",
     "lodash.map": "^4.0.0",
     "lodash.mapkeys": "^4.1.0",
@@ -60,8 +61,11 @@
     "moment": "^2.11.1",
     "normalize.css": "^3.0.3",
     "purecss": "^0.6.0",
+    "run-parallel": "^1.1.4",
     "sluggo": "^0.2.0",
-    "url-join": "0.0.1"
+    "url": "^0.11.0",
+    "url-join": "0.0.1",
+    "whatwg-fetch": "^0.11.0"
   },
   "eslintConfig": {
     "extends": "arenanet",

--- a/src/lib/update.js
+++ b/src/lib/update.js
@@ -7,7 +7,7 @@ function update(obj, path, val) {
         return;
     }
 
-    set(obj, path, (val === false || val === "") ? null : val);
+    set(obj, path, (val === undefined || val === false || val === "") ? null : val);
 }
 
 module.exports = function(obj, path, val) {

--- a/src/pages/content-edit/head.js
+++ b/src/pages/content-edit/head.js
@@ -127,8 +127,18 @@ module.exports = {
         };
 
         ctrl.save = function() {
-            ref.child("fields").set(options.data.fields);
-            ref.child("name").set(options.data.name);
+            ctrl.saving = true;
+            
+            m.redraw();
+            
+            ref.update({
+                fields : options.data.fields,
+                name   : options.data.name
+            }, function() {
+                ctrl.saving = false;
+                
+                m.redraw();
+            });
         };
     },
 
@@ -153,7 +163,8 @@ module.exports = {
                     upper(status)
                 ),
                 m("div", { class : css.actions },
-                    m("button", {
+                    ctrl.saving ?
+                        "SAVING..." : m("button", {
                             // Attrs
                             class    : css.save,
                             title    : "Save your changes",

--- a/src/types/children.js
+++ b/src/types/children.js
@@ -51,6 +51,7 @@ types = {
     // Custom input types
     relationship : require("./relationship"),
     textarea     : require("./textarea"),
+    upload       : require("./upload"),
     
     // Implementations based on lib/multiple.js
     select   : require("./select"),

--- a/src/types/upload.css
+++ b/src/types/upload.css
@@ -1,0 +1,92 @@
+@value flex_css:    "../flex.css";
+@value icons_css:   "../icons.css";
+@value buttons_css: "../buttons.css";
+
+@keyframes flash {
+    to {
+        background-color: rgba(0, 0, 0, 0.3);
+    }
+}
+
+.target {
+    composes: hbox from flex_css;
+    
+    min-height: 100px;
+    background: rgba(0, 0, 0, 0.05);
+    border: 1px solid #CCC;
+    box-shadow: inset 0 1px 3px #DDD;
+    
+    border-radius: 4px;
+}
+
+.highlight {
+    composes: target;
+    
+    animation: flash 0.5s ease-in-out infinite alternate;
+}
+
+.instructions {
+    text-align: center;
+    
+    flex: 1;
+}
+
+.queue {
+    padding: 0;
+    margin: 0;
+    
+    flex: 1;
+}
+
+.queued {
+    composes: hbox from flex_css;
+    
+    list-style: none;
+    
+    padding: 10px;
+}
+
+.queued + .queued {
+    margin-top: 10px;
+}
+
+.queued:nth-child(2n) {
+    background: rgba(0, 0, 0, 0.2);
+}
+
+.image {
+    width: 200px;
+}
+
+.img {
+    width: 100%;   
+    min-height: 25px;
+    max-height: 100px;
+    
+    object-fit: contain;
+    object-position: 50% 0;
+}
+
+.meta {
+    composes: vbox from flex_css;
+    
+    flex: 1;
+    
+    margin-left: 20px;
+}
+
+.name {
+    margin: 0;
+}
+
+.actions {
+    composes: vbox from flex_css;
+}
+
+.remove {
+    composes: plain from buttons_css;
+}
+
+.icon {
+    composes: icon from icons_css;
+}

--- a/src/types/upload.js
+++ b/src/types/upload.js
@@ -1,0 +1,306 @@
+/* global Promise, fetch */
+"use strict";
+
+var m        = require("mithril"),
+    filter   = require("lodash.filter"),
+    each     = require("lodash.foreach"),
+    parallel = require("run-parallel"),
+    join     = require("url-join"),
+    url      = require("url"),
+    path     = require("path"),
+    
+    id    = require("./lib/id"),
+    hide  = require("./lib/hide"),
+    label = require("./lib/label"),
+    
+    css = require("./upload.css"),
+    
+    icons = global.crucible.icons;
+
+// Load fetch polyfill
+require("whatwg-fetch");
+
+function status(response) {
+    // Assume opaque responses are cool, because who knows?
+    return response.type === "opaque" || (response.status >= 200 && response.status < 300);
+}
+
+// Helper
+function checkStatus(response) {
+    var error;
+    
+    if(status(response)) {
+        return response;
+    }
+    
+    error = new Error(response.statusText);
+    error.response = response;
+    
+    throw error;
+}
+
+function name(remote) {
+    return path.basename(url.parse(remote).path);
+}
+
+module.exports = {
+    controller : function(options) {
+        var ctrl = this;
+        
+        if(!options.field.ws) {
+            console.error("No ws for upload field");
+            // throw new Error("Must define a ws for upload fields");
+        }
+        
+        ctrl.id = id(options);
+        
+        // Drag-n-drop state tracking
+        ctrl.dragging  = false;
+        ctrl.uploading = false;
+        
+        if(options.data) {
+            if(typeof options.data === "string") {
+                options.data = [ options.data ];
+            }
+            
+            ctrl.files = options.data.map(function(remote) {
+                return {
+                    name     : name(remote),
+                    uploaded : true,
+                    remote   : remote
+                };
+            });
+        } else {
+            ctrl.files = [];
+        }
+                
+        // Event handlers
+        ctrl.remove = function(idx, e) {
+            e.preventDefault();
+            
+            ctrl.files.splice(idx, 1);
+            
+            ctrl._update();
+        };
+        
+        ctrl.dragon = function(e) {
+            e.preventDefault();
+
+            if(ctrl.dragging) {
+                m.redraw.strategy("none");
+                return;
+            }
+            
+            // Don't show this as a drag target if there's already something there
+            // and it's not a multiple field
+            if(ctrl.files.length && !options.field.multiple) {
+                m.redraw.strategy("none");
+                return;
+            }
+            
+            ctrl.dragging = true;
+        };
+
+        ctrl.dragoff = function() {
+            ctrl.dragging = false;
+        };
+
+        ctrl.drop = function(e) {
+            var dropped;
+            
+            ctrl.dragoff();
+            e.preventDefault();
+            
+            // Must delete existing file before dragging on more
+            if(ctrl.files.length && !options.field.multiple) {
+                return;
+            }
+            
+            // Filter out non-images
+            dropped = filter((e.dataTransfer || e.target).files, function(file) {
+                return file.type.indexOf("image/") === 0;
+            });
+            
+            if(options.field.multiple) {
+                ctrl.files = ctrl.files.concat(dropped);
+            } else {
+                ctrl.files = dropped.slice(-1);
+            }
+            
+            // Load all the images in parallel so we can show previews
+            parallel(
+                ctrl.files
+                .filter(function(file) {
+                    return !file.uploaded;
+                })
+                .map(function(file) {
+                    return function(callback) {
+                        var reader = new FileReader();
+
+                        reader.onload = function(result) {
+                            file.src = result.target.result;
+                            
+                            callback();
+                        };
+
+                        reader.readAsDataURL(file);
+                    };
+                }),
+                
+                function(err) {
+                    if(err) {
+                        return console.error(err);
+                    }
+                    
+                    m.redraw();
+                    
+                    return ctrl._upload();
+                }
+            );
+        };
+        
+        // Update w/ the result, but removing anything that hasn't been uploaded
+        ctrl._update = function() {
+            var files = ctrl.files.filter(function(file) {
+                    return file.uploaded && file.remote;
+                }).map(function(file) {
+                    return file.remote;
+                });
+            
+            options.update(
+                options.path,
+                options.field.multiple ? files : files[0]
+            );
+        };
+        
+        // Upload any files that haven't been uploaded yet
+        ctrl._upload = function() {
+            var files = files = ctrl.files.filter(function(file) {
+                    return !file.uploaded && !file.uploading;
+                });
+            
+            if(!files.length) {
+                return;
+            }
+            
+            fetch(options.field.ws)
+            .then(checkStatus)
+            .then(function(response) {
+                return response.json();
+            })
+            .then(function(config) {
+                files.forEach(function(file) {
+                    file.uploading = true;
+                });
+                
+                // queue a redraw here so we can show uploading status
+                m.redraw();
+                
+                return Promise.all(
+                    files.map(function(file) {
+                        var data = new FormData();
+                        
+                        each(config.fields, function(val, key) {
+                            data.append(key, val);
+                        });
+                        
+                        data.append(config.filefield, file);
+                        
+                        return fetch(config.action, {
+                            method : "post",
+                            body   : data,
+                            mode   : "cors"
+                        })
+                        .then(function(response) {
+                            if(status(response)) {
+                                file.uploaded  = true;
+                                file.uploading = false;
+                                file.remote    = join(config.action, config.fields.key.replace("${filename}", file.name));
+                            }
+                            
+                            // queue a redraw as each file completes/fails
+                            m.redraw();
+                            
+                            return file;
+                        });
+                    })
+                );
+            })
+            .then(ctrl._update)
+            .catch(function(error) {
+                // TODO: error-handling
+                console.error(error);
+            });
+        };
+    },
+    
+    view : function(ctrl, options) {
+        var field  = options.field,
+            hidden = hide(options);
+        
+        if(hidden) {
+            return hidden;
+        }
+
+        return m("div", { class : options.class },
+            label(ctrl, options),
+            m("div", {
+                    // Attrs
+                    class : css[ctrl.dragging ? "highlight" : "target"],
+                    
+                    // Events
+                    ondragover  : ctrl.dragon,
+                    ondragleave : ctrl.dragoff,
+                    ondragend   : ctrl.dragoff,
+                    ondrop      : ctrl.drop
+                },
+                ctrl.files.length ?
+                    m("ul", { class : css.queue },
+                        ctrl.files.map(function(file, idx) {
+                            return m("li", { class : css.queued },
+                                m("div", { class : css.image },
+                                    m("img", {
+                                        class : css.img,
+                                        src   : file.remote || file.src
+                                    })
+                                ),
+                                m("div", { class : css.meta },
+                                    m("p", { class : css.name }, file.name),
+                                    file.uploading ?
+                                        m("p", "UPLOADING") :
+                                        null,
+                                    file.uploaded ?
+                                        m("input", {
+                                            value   : file.remote,
+                                            onclick : function(e) {
+                                                e.target.select();
+                                            }
+                                        }) :
+                                        null
+                                ),
+                                m("div", { class : css.actions },
+                                    m("button", {
+                                            // Attrs
+                                            class : css.remove,
+                                            title : "Remove",
+                                            
+                                            // Events
+                                            onclick : ctrl.remove.bind(ctrl, idx)
+                                        },
+                                        m("svg", { class : css.icon },
+                                            m("use", { href : icons + "#remove" })
+                                        )
+                                    )
+                                )
+                            );
+                        })
+                    ) :
+                        
+                    m("p", { class : css.instructions }, field.multiple ?
+                        "Drop files here to upload" :
+                        "Drop a file here to upload"
+                    )
+            )
+        );
+    }
+};


### PR DESCRIPTION
Using a third-party server to get the URL and any params required for uploads, to side-step dealing w/ secret keys or anything else. Supports both single & multiple file uploads. Uploads start immediately after dragging files, but the URL to the upload isn't persisted into firebase until you click "Save".


```js
{
    upload: {
        type : "upload",
        ws   : "http://upload-endpoint.com"
    },

    multiple: {
        type : "upload",
        ws   : "upload-endpoint.com",
        multiple : true
    }
}
```

Endpoint should return an object like this:

```js
{
    // Upload destination
    action    : "http://upload-destionation.com/upload",
    // Name for the file field in the submitted form
    filefield : "file",

    // Any other form data you want sent along with the file data
    fields : {
        key : dir + "-${filename}",
        acl  : acl,
        policy : policy,
        ...
    }
}
```