### PR TITLE
Fixed a bug with setting values for repeating types

### DIFF
--- a/src/types/repeating.js
+++ b/src/types/repeating.js
@@ -49,7 +49,7 @@ module.exports = {
                     return;
                 }
                 
-                opts.update(opts.path.concat(idx), "placeholder");
+                opts.update(opts.path.concat(idx), {});
             });
         };
 


### PR DESCRIPTION
lodash.set in update.js gives up when running into a string in the path
it's trying to set.  If only there were a way to just make it override
it.. This is a workaround so that I can set dates within a repeating
type.