### PR TITLE
Objectify exports for children.js imports.

### DIFF
--- a/src/types/children.js
+++ b/src/types/children.js
@@ -56,19 +56,19 @@ export function view(ctrl, options) {
 }
 
 // Structural
-import * as fieldset from "./fieldset.js";
-import * as repeating from "./repeating.js";
-import * as split from "./split.js";
-import * as tabs from "./tabs.js";
+import fieldset from "./fieldset.js";
+import repeating from "./repeating.js";
+import split from "./split.js";
+import tabs from "./tabs.js";
 
 // Non-input fields
-import * as instructions from "./instructions.js";
+import instructions from "./instructions.js";
 
 // Custom input types
-import * as relationship from "./relationship.js";
-import * as markdown from "./markdown.js";
-import * as textarea from "./textarea.js";
-import * as upload from "./upload.js";
+import relationship from "./relationship.js";
+import markdown from "./markdown.js";
+import textarea from "./textarea.js";
+import upload from "./upload.js";
 
 // Implementations based on lib/multiple.js
 import select from "./select.js";

--- a/src/types/fieldset.js
+++ b/src/types/fieldset.js
@@ -5,11 +5,13 @@ import * as children from "./children.js";
 
 import css from "./fieldset.css";
 
-export function view(ctrl, options) {   
-    return m("fieldset", { class : options.class },
-        options.field.name ? m("legend", { class : css.legend }, options.field.name) : null,
-        m.component(children, assign({}, options, {
-            fields : options.field.children
-        }))
-    );
-}
+export default {
+    view : function(ctrl, options) {   
+        return m("fieldset", { class : options.class },
+            options.field.name ? m("legend", { class : css.legend }, options.field.name) : null,
+            m.component(children, assign({}, options, {
+                fields : options.field.children
+            }))
+        );
+    }
+};

--- a/src/types/instructions.js
+++ b/src/types/instructions.js
@@ -2,11 +2,13 @@ import m from "mithril";
 
 import css from "./instructions.css";
 
-export function view(ctrl, options) {
-    var field  = options.field;
+export default {
+    view : function(ctrl, options) {
+        var field  = options.field;
 
-    return m("div", { class : options.class },
-        field.head ? m("p", { class : css.head }, field.head) : null,
-        field.body ? m("p", field.body) : null
-    );
-}
+        return m("div", { class : options.class },
+            field.head ? m("p", { class : css.head }, field.head) : null,
+            field.body ? m("p", field.body) : null
+        );
+    }
+};

--- a/src/types/markdown.js
+++ b/src/types/markdown.js
@@ -11,63 +11,65 @@ var md = new Remarkable();
 
 import "codemirror/mode/markdown/markdown";
 
-export function controller(options) {
-    var ctrl = this;
-    
-    ctrl.id       = id(options);
-    ctrl.markdown = options.data || "";
-    ctrl.previewing = false;
-    ctrl.previewHTML = null;
-    
-    ctrl.options = options;
+export default {
+    controller (options) {
+        var ctrl = this;
+        
+        ctrl.id       = id(options);
+        ctrl.markdown = options.data || "";
+        ctrl.previewing = false;
+        ctrl.previewHTML = null;
+        
+        ctrl.options = options;
 
-    ctrl.togglePreview = function(e) {
-        e.preventDefault();
+        ctrl.togglePreview = function(e) {
+            e.preventDefault();
 
-        ctrl.previewHTML = md.render(ctrl.markdown);
-        ctrl.previewing = !ctrl.previewing;
-    };
+            ctrl.previewHTML = md.render(ctrl.markdown);
+            ctrl.previewing = !ctrl.previewing;
+        };
 
-    ctrl.editorChanged = function() {
-        ctrl.markdown = ctrl.editor.doc.getValue();
+        ctrl.editorChanged = function() {
+            ctrl.markdown = ctrl.editor.doc.getValue();
 
-        ctrl.options.update(ctrl.options.path, ctrl.markdown);
-    };
+            ctrl.options.update(ctrl.options.path, ctrl.markdown);
+        };
 
-    ctrl.editorSetup = function(el, init) {
-        if(init) {
-            return;
-        }
+        ctrl.editorSetup = function(el, init) {
+            if(init) {
+                return;
+            }
 
-        ctrl.editor = editor.fromTextArea(el, {
-            mode : "text/x-markdown",
+            ctrl.editor = editor.fromTextArea(el, {
+                mode : "text/x-markdown",
 
-            indentUnit   : 4,
-            lineWrapping : true
-        });
+                indentUnit   : 4,
+                lineWrapping : true
+            });
 
-        ctrl.editor.on("changes", ctrl.editorChanged);
-    };
-}
+            ctrl.editor.on("changes", ctrl.editorChanged);
+        };
+    },
 
-export function view(ctrl, options) {
-    ctrl.options = options;
+    view : function(ctrl, options) {
+        ctrl.options = options;
 
-    return m("div", { class : options.class },
-        label(ctrl, options),
-        m("div", { class : ctrl.previewing ? css.inputHidden : css.input },
-            m("textarea", { config : ctrl.editorSetup },
-                ctrl.markdown
+        return m("div", { class : options.class },
+            label(ctrl, options),
+            m("div", { class : ctrl.previewing ? css.inputHidden : css.input },
+                m("textarea", { config : ctrl.editorSetup },
+                    ctrl.markdown
+                )
+            ),
+            m("div", { class : ctrl.previewing ? css.input : css.inputHidden },
+                m.trust(ctrl.previewHTML)
+            ),
+            m("button.pure-button", {
+                    onclick : ctrl.togglePreview,
+                    class   : css.button
+                },
+                ctrl.previewing ? "Edit" : "Preview"
             )
-        ),
-        m("div", { class : ctrl.previewing ? css.input : css.inputHidden },
-            m.trust(ctrl.previewHTML)
-        ),
-        m("button.pure-button", {
-                onclick : ctrl.togglePreview,
-                class   : css.button
-            },
-            ctrl.previewing ? "Edit" : "Preview"
-        )
-    );
-}
+        );
+    }
+};

--- a/src/types/relationship.js
+++ b/src/types/relationship.js
@@ -10,140 +10,142 @@ import types from "./lib/types.css";
 
 import css from "./relationship.css";
 
-export function controller(options) {
-    var ctrl    = this,
-        schema  = options.field.schema,
-        content = db.child("content/" + schema);
+export default {
+    controller : function(options) {
+        var ctrl    = this,
+            schema  = options.field.schema,
+            content = db.child("content/" + schema);
 
-    ctrl.id      = id(options);
-    ctrl.lookup  = null;
-    ctrl.handle  = null;
-    ctrl.related = null;
-    ctrl.names   = [];
-    
-    ctrl.options = options;
+        ctrl.id      = id(options);
+        ctrl.lookup  = null;
+        ctrl.handle  = null;
+        ctrl.related = null;
+        ctrl.names   = [];
+        
+        ctrl.options = options;
 
-    ctrl.config = function(el, init) {
-        if(init) {
-            return;
-        }
+        ctrl.config = function(el, init) {
+            if(init) {
+                return;
+            }
 
-        ctrl.autocomplete = new Awesomeplete(el, {
-            minChars  : 3,
-            maxItems  : 10,
-            autoFirst : true
-        });
-
-        ctrl.input = el;
-
-        el.addEventListener("awesomplete-selectcomplete", ctrl.add);
-
-        ctrl.autocomplete.list = ctrl.names;
-
-        ctrl.load();
-    };
-
-    ctrl.load = function() {
-        if(ctrl.handle) {
-            return;
-        }
-
-        ctrl.handle = content.on("value", function(snap) {
-            ctrl.lookup  = {};
-            ctrl.related = snap.val();
-            ctrl.names   = [];
-
-            snap.forEach(function(details) {
-                var val = details.val();
-
-                ctrl.names.push(val.name);
-
-                ctrl.lookup[val.name] = details.key();
+            ctrl.autocomplete = new Awesomeplete(el, {
+                minChars  : 3,
+                maxItems  : 10,
+                autoFirst : true
             });
 
-            if(ctrl.autocomplete) {
-                ctrl.autocomplete.list = ctrl.names;
-                ctrl.autocomplete.evaluate();
+            ctrl.input = el;
+
+            el.addEventListener("awesomplete-selectcomplete", ctrl.add);
+
+            ctrl.autocomplete.list = ctrl.names;
+
+            ctrl.load();
+        };
+
+        ctrl.load = function() {
+            if(ctrl.handle) {
+                return;
             }
 
-            m.redraw();
-        });
-    };
+            ctrl.handle = content.on("value", function(snap) {
+                ctrl.lookup  = {};
+                ctrl.related = snap.val();
+                ctrl.names   = [];
 
-    // Set up a two-way relationship between these
-    ctrl.add = function(e) {
-        var key = ctrl.lookup[e.target.value];
+                snap.forEach(function(details) {
+                    var val = details.val();
 
-        if(!key) {
-            console.error(e.target.value);
+                    ctrl.names.push(val.name);
 
-            return;
-        }
+                    ctrl.lookup[val.name] = details.key();
+                });
 
-        e.target.value = "";
-
-        ctrl.options.update(ctrl.options.path.concat(key), true);
-
-        if(ctrl.options.root) {
-            content.child(key + "/relationships/" + ctrl.options.root.key()).set(true);
-        }
-    };
-
-    // BREAK THE RELATIONSHIP
-    // TODO: Maybe broken?
-    ctrl.remove = function(tgt, e) {
-        var key = ctrl.lookup[e.target.value];
-
-        e.preventDefault();
-        
-        options.update(options.path.concat(tgt), false);
-        
-        if(options.root) {
-            content.child(key + "/relationships/" + options.root.key()).remove();
-        }
-    };
-
-    if(options.data) {
-        ctrl.load();
-    }
-}
-
-export function view(ctrl, options) {
-    var field  = options.field;
-    
-    ctrl.options = options;
-
-    return m("div", { class : options.class },
-        label(ctrl, options),
-        m("input", assign(field.attrs || {}, {
-            // Attrs
-            id     : ctrl.id,
-            class  : types.input,
-            config : ctrl.config,
-
-            // Events
-            onkeydown : function(e) {
-                if(e.keyCode !== 9 || ctrl.autocomplete.opened === false) {
-                    return;
+                if(ctrl.autocomplete) {
+                    ctrl.autocomplete.list = ctrl.names;
+                    ctrl.autocomplete.evaluate();
                 }
 
-                ctrl.autocomplete.select();
+                m.redraw();
+            });
+        };
+
+        // Set up a two-way relationship between these
+        ctrl.add = function(e) {
+            var key = ctrl.lookup[e.target.value];
+
+            if(!key) {
+                console.error(e.target.value);
+
+                return;
             }
-        })),
-        m("div", { class : css.relationships },
-            options.data && Object.keys(options.data).map(function(key) {
-                return m("div", { class : css.relationship },
-                    m("p", { class : css.name },
-                        ctrl.related ? ctrl.related[key].name : "Loading..."
-                    ),
-                    m("div", { class : css.actions },
-                        m("button", {
-                            class   : css.remove,
-                            onclick : ctrl.remove.bind(ctrl, key)
-                        }, "Remove")
-                    )
-                );
-            })
-        )
-    );
-}
+
+            e.target.value = "";
+
+            ctrl.options.update(ctrl.options.path.concat(key), true);
+
+            if(ctrl.options.root) {
+                content.child(key + "/relationships/" + ctrl.options.root.key()).set(true);
+            }
+        };
+
+        // BREAK THE RELATIONSHIP
+        // TODO: Maybe broken?
+        ctrl.remove = function(tgt, e) {
+            var key = ctrl.lookup[e.target.value];
+
+            e.preventDefault();
+            
+            options.update(options.path.concat(tgt), false);
+            
+            if(options.root) {
+                content.child(key + "/relationships/" + options.root.key()).remove();
+            }
+        };
+
+        if(options.data) {
+            ctrl.load();
+        }
+    },
+
+    view : function(ctrl, options) {
+        var field  = options.field;
+        
+        ctrl.options = options;
+
+        return m("div", { class : options.class },
+            label(ctrl, options),
+            m("input", assign(field.attrs || {}, {
+                // Attrs
+                id     : ctrl.id,
+                class  : types.input,
+                config : ctrl.config,
+
+                // Events
+                onkeydown : function(e) {
+                    if(e.keyCode !== 9 || ctrl.autocomplete.opened === false) {
+                        return;
+                    }
+
+                    ctrl.autocomplete.select();
+                }
+            })),
+            m("div", { class : css.relationships },
+                options.data && Object.keys(options.data).map(function(key) {
+                    return m("div", { class : css.relationship },
+                        m("p", { class : css.name },
+                            ctrl.related ? ctrl.related[key].name : "Loading..."
+                        ),
+                        m("div", { class : css.actions },
+                            m("button", {
+                                class   : css.remove,
+                                onclick : ctrl.remove.bind(ctrl, key)
+                            }, "Remove")
+                        )
+                    );
+                })
+            )
+        );
+    }
+};

--- a/src/types/repeating.js
+++ b/src/types/repeating.js
@@ -33,7 +33,6 @@ function child(ctrl, options, data, idx) {
 }
 
 export default {
-
     controller : function(options) {
         var ctrl = this;
         
@@ -72,7 +71,7 @@ export default {
     },
 
     view : function(ctrl, options) {
-        var field   = options.field,
+        var field = options.field,
             items;
         
         if(options.data) {

--- a/src/types/repeating.js
+++ b/src/types/repeating.js
@@ -32,58 +32,61 @@ function child(ctrl, options, data, idx) {
     );
 }
 
-export function controller(options) {
-    var ctrl = this;
-    
-    ctrl.children = (options.data && options.data.length) || 1;
-    
-    ctrl.add = function(opts, e) {
-        e.preventDefault();
-        
-        ctrl.children += 1;
+export default {
 
-        // Ensure that we have data placeholders for all the possible entries
-        times(ctrl.children, function(idx) {
-            if(opts.data && opts.data[idx]) {
-                return;
+    controller : function(options) {
+        var ctrl = this;
+        
+        ctrl.children = (options.data && options.data.length) || 1;
+        
+        ctrl.add = function(opts, e) {
+            e.preventDefault();
+            
+            ctrl.children += 1;
+
+            // Ensure that we have data placeholders for all the possible entries
+            times(ctrl.children, function(idx) {
+                if(opts.data && opts.data[idx]) {
+                    return;
+                }
+                
+                // Need a key here so that firebase will save this object,
+                // otherwise future loads can have weird gaps
+                opts.update(opts.path.concat(idx), { __idx : idx });
+            });
+        };
+
+        ctrl.remove = function(opts, data, idx, e) {
+            e.preventDefault();
+            
+            if(Array.isArray(opts.data)) {
+                opts.data.splice(idx, 1);
+                
+                ctrl.children = opts.data.length;
+            } else {
+                --ctrl.children;
             }
             
-            // Need a key here so that firebase will save this object,
-            // otherwise future loads can have weird gaps
-            opts.update(opts.path.concat(idx), { __idx : idx });
-        });
-    };
+            opts.update(opts.path, opts.data);
+        };
+    },
 
-    ctrl.remove = function(opts, data, idx, e) {
-        e.preventDefault();
+    view : function(ctrl, options) {
+        var field   = options.field,
+            items;
         
-        if(Array.isArray(opts.data)) {
-            opts.data.splice(idx, 1);
-            
-            ctrl.children = opts.data.length;
+        if(options.data) {
+            items = options.data.map(child.bind(null, ctrl, options));
         } else {
-            --ctrl.children;
+            items = times(ctrl.children, child.bind(null, ctrl, options, false));
         }
         
-        opts.update(opts.path, opts.data);
-    };
-}
-
-export function view(ctrl, options) {
-    var field   = options.field,
-        items;
-    
-    if(options.data) {
-        items = options.data.map(child.bind(null, ctrl, options));
-    } else {
-        items = times(ctrl.children, child.bind(null, ctrl, options, false));
+        return m("div", { class : options.class + " " + css.container },
+            items,
+            m("button", {
+                class   : css.add,
+                onclick : ctrl.add.bind(null, options)
+            }, field.button || "Add")
+        );
     }
-    
-    return m("div", { class : options.class + " " + css.container },
-        items,
-        m("button", {
-            class   : css.add,
-            onclick : ctrl.add.bind(null, options)
-        }, field.button || "Add")
-    );
-}
+};

--- a/src/types/split.js
+++ b/src/types/split.js
@@ -6,19 +6,21 @@ import * as instructions from "./instructions";
 
 import css from "./split.css";
 
-export function view(ctrl, options) {
-    var field  = options.field;
-    
-    return m("div", { class : css.container },
-        field.instructions ? m.component(instructions, { field : field.instructions }) : null,
-        (field.children || []).map(function(section) {
-            return m("div", { class : css.section },
-                m.component(children, assign({}, options, {
-                    // Don't want to repeat any incoming class that children might've passed in
-                    class  : false,
-                    fields : section.children
-                }))
-            );
-        })
-    );
-}
+export default {
+    view : function(ctrl, options) {
+        var field  = options.field;
+        
+        return m("div", { class : css.container },
+            field.instructions ? m.component(instructions, { field : field.instructions }) : null,
+            (field.children || []).map(function(section) {
+                return m("div", { class : css.section },
+                    m.component(children, assign({}, options, {
+                        // Don't want to repeat any incoming class that children might've passed in
+                        class  : false,
+                        fields : section.children
+                    }))
+                );
+            })
+        );
+    }
+};

--- a/src/types/tabs.js
+++ b/src/types/tabs.js
@@ -4,41 +4,43 @@ import assign from "lodash.assign";
 import * as children from "./children";
 import css from "./tabs.css";
 
-export function controller() {
-    var ctrl = this;
+export default {
+    controller : function() {
+        var ctrl = this;
 
-    ctrl.tab = 0;
+        ctrl.tab = 0;
 
-    ctrl.switchtab = function(tab, e) {
-        e.preventDefault();
+        ctrl.switchtab = function(tab, e) {
+            e.preventDefault();
 
-        ctrl.tab = tab;
-    };
-}
+            ctrl.tab = tab;
+        };
+    },
 
-export function view(ctrl, options) {
-    var tabs   = options.field.children || [];
-    
-    return m("div", { class : options.class },
-        m("div", { class : css.nav },
+    view : function(ctrl, options) {
+        var tabs   = options.field.children || [];
+        
+        return m("div", { class : options.class },
+            m("div", { class : css.nav },
+                tabs.map(function(tab, idx) {
+                    return m("a", {
+                            class   : css[idx === ctrl.tab ? "activetab" : "tab"],
+                            href    : "#" + idx,
+                            onclick : ctrl.switchtab.bind(ctrl, idx)
+                        }, tab.name
+                    );
+                })
+            ),
             tabs.map(function(tab, idx) {
-                return m("a", {
-                        class   : css[idx === ctrl.tab ? "activetab" : "tab"],
-                        href    : "#" + idx,
-                        onclick : ctrl.switchtab.bind(ctrl, idx)
-                    }, tab.name
+                return m("div", { class : css[idx === ctrl.tab ? "activebody" : "body"] },
+                    m.component(children, assign({}, options, {
+                        class  : false,
+                        fields : tab.children,
+                        data   : options.data && options.data[tab.key],
+                        path   : options.path.concat(tab.key)
+                    }))
                 );
             })
-        ),
-        tabs.map(function(tab, idx) {
-            return m("div", { class : css[idx === ctrl.tab ? "activebody" : "body"] },
-                m.component(children, assign({}, options, {
-                    class  : false,
-                    fields : tab.children,
-                    data   : options.data && options.data[tab.key],
-                    path   : options.path.concat(tab.key)
-                }))
-            );
-        })
-    );
-}
+        );
+    }
+};

--- a/src/types/textarea.js
+++ b/src/types/textarea.js
@@ -41,4 +41,4 @@ export default {
             )
         );
     }
-}
+};

--- a/src/types/textarea.js
+++ b/src/types/textarea.js
@@ -6,37 +6,39 @@ import label from "./lib/label";
 
 import css from "./textarea.css";
 
-export function controller(options) {
-    var ctrl = this;
+export default {
+    controller : function(options) {
+        var ctrl = this;
 
-    ctrl.id   = id(options);
-    ctrl.text = options.data || "";
+        ctrl.id   = id(options);
+        ctrl.text = options.data || "";
 
-    ctrl.resize = function(opt, value) {
-        opt.update(opt.path, value);
+        ctrl.resize = function(opt, value) {
+            opt.update(opt.path, value);
 
-        ctrl.text = value;
-    };
-}
+            ctrl.text = value;
+        };
+    },
 
-export function view(ctrl, options) {
-    var field  = options.field;
+    view : function(ctrl, options) {
+        var field  = options.field;
 
-    return m("div", { class : options.class },
-        label(ctrl, options),
-        m("div", { class : css.expander },
-            m("pre", { class : css.shadow }, m("span", ctrl.text), m("br")),
-            m("textarea", assign({
-                    // attrs
-                    id       : ctrl.id,
-                    class    : css.textarea,
-                    required : field.required ? "required" : null,
+        return m("div", { class : options.class },
+            label(ctrl, options),
+            m("div", { class : css.expander },
+                m("pre", { class : css.shadow }, m("span", ctrl.text), m("br")),
+                m("textarea", assign({
+                        // attrs
+                        id       : ctrl.id,
+                        class    : css.textarea,
+                        required : field.required ? "required" : null,
 
-                    // events
-                    oninput : m.withAttr("value", ctrl.resize.bind(null, options))
-                },
-                field.attrs || {}
-            ), options.data || "")
-        )
-    );
+                        // events
+                        oninput : m.withAttr("value", ctrl.resize.bind(null, options))
+                    },
+                    field.attrs || {}
+                ), options.data || "")
+            )
+        );
+    }
 }

--- a/src/types/upload.js
+++ b/src/types/upload.js
@@ -42,270 +42,272 @@ function name(remote) {
     return path.basename(url.parse(remote).path);
 }
 
-export function controller(options) {
-    var ctrl = this;
-    
-    if(!options.field.ws) {
-        console.error("No ws for upload field");
-        // throw new Error("Must define a ws for upload fields");
-    }
-    
-    ctrl.id = id(options);
-    
-    // Drag-n-drop state tracking
-    ctrl.dragging  = false;
-    ctrl.uploading = false;
-    
-    // Options caching
-    ctrl.options = options;
-    
-    if(options.data) {
-        if(typeof options.data === "string") {
-            options.data = [ options.data ];
+export default {
+    controller : function(options) {
+        var ctrl = this;
+        
+        if(!options.field.ws) {
+            console.error("No ws for upload field");
+            // throw new Error("Must define a ws for upload fields");
         }
         
-        ctrl.files = options.data.map(function(remote) {
-            return {
-                name     : name(remote),
-                uploaded : true,
-                remote   : remote
-            };
-        });
-    } else {
-        ctrl.files = [];
-    }
+        ctrl.id = id(options);
+        
+        // Drag-n-drop state tracking
+        ctrl.dragging  = false;
+        ctrl.uploading = false;
+        
+        // Options caching
+        ctrl.options = options;
+        
+        if(options.data) {
+            if(typeof options.data === "string") {
+                options.data = [ options.data ];
+            }
             
-    // Event handlers
-    ctrl.remove = function(idx, e) {
-        e.preventDefault();
-        
-        ctrl.files.splice(idx, 1);
-        
-        ctrl._update();
-    };
-    
-    ctrl.dragon = function(e) {
-        e.preventDefault();
-
-        if(ctrl.dragging) {
-            m.redraw.strategy("none");
-
-            return;
-        }
-        
-        // Don't show this as a drag target if there's already something there
-        // and it's not a multiple field
-        if(ctrl.files.length && !ctrl.options.field.multiple) {
-            m.redraw.strategy("none");
-            
-            return;
-        }
-        
-        ctrl.dragging = true;
-    };
-
-    ctrl.dragoff = function() {
-        ctrl.dragging = false;
-    };
-
-    ctrl.drop = function(e) {
-        var dropped;
-        
-        ctrl.dragoff();
-        e.preventDefault();
-        
-        // Must delete existing file before dragging on more
-        if(ctrl.files.length && !ctrl.options.field.multiple) {
-            return;
-        }
-        
-        // Filter out non-images
-        dropped = filter((e.dataTransfer || e.target).files, function(file) {
-            return file.type.indexOf("image/") === 0;
-        });
-        
-        if(ctrl.options.field.multiple) {
-            ctrl.files = ctrl.files.concat(dropped);
-        } else {
-            ctrl.files = dropped.slice(-1);
-        }
-        
-        // Load all the images in parallel so we can show previews
-        parallel(
-            ctrl.files
-            .filter(function(file) {
-                return !file.uploaded;
-            })
-            .map(function(file) {
-                return function(callback) {
-                    var reader = new FileReader();
-
-                    reader.onload = function(result) {
-                        file.src = result.target.result;
-                        
-                        callback();
-                    };
-
-                    reader.readAsDataURL(file);
+            ctrl.files = options.data.map(function(remote) {
+                return {
+                    name     : name(remote),
+                    uploaded : true,
+                    remote   : remote
                 };
-            }),
-            
-            function(err) {
-                if(err) {
-                    return console.error(err);
-                }
+            });
+        } else {
+            ctrl.files = [];
+        }
                 
+        // Event handlers
+        ctrl.remove = function(idx, e) {
+            e.preventDefault();
+            
+            ctrl.files.splice(idx, 1);
+            
+            ctrl._update();
+        };
+        
+        ctrl.dragon = function(e) {
+            e.preventDefault();
+
+            if(ctrl.dragging) {
+                m.redraw.strategy("none");
+
+                return;
+            }
+            
+            // Don't show this as a drag target if there's already something there
+            // and it's not a multiple field
+            if(ctrl.files.length && !ctrl.options.field.multiple) {
+                m.redraw.strategy("none");
+                
+                return;
+            }
+            
+            ctrl.dragging = true;
+        };
+
+        ctrl.dragoff = function() {
+            ctrl.dragging = false;
+        };
+
+        ctrl.drop = function(e) {
+            var dropped;
+            
+            ctrl.dragoff();
+            e.preventDefault();
+            
+            // Must delete existing file before dragging on more
+            if(ctrl.files.length && !ctrl.options.field.multiple) {
+                return;
+            }
+            
+            // Filter out non-images
+            dropped = filter((e.dataTransfer || e.target).files, function(file) {
+                return file.type.indexOf("image/") === 0;
+            });
+            
+            if(ctrl.options.field.multiple) {
+                ctrl.files = ctrl.files.concat(dropped);
+            } else {
+                ctrl.files = dropped.slice(-1);
+            }
+            
+            // Load all the images in parallel so we can show previews
+            parallel(
+                ctrl.files
+                .filter(function(file) {
+                    return !file.uploaded;
+                })
+                .map(function(file) {
+                    return function(callback) {
+                        var reader = new FileReader();
+
+                        reader.onload = function(result) {
+                            file.src = result.target.result;
+                            
+                            callback();
+                        };
+
+                        reader.readAsDataURL(file);
+                    };
+                }),
+                
+                function(err) {
+                    if(err) {
+                        return console.error(err);
+                    }
+                    
+                    m.redraw();
+                    
+                    return ctrl._upload();
+                }
+            );
+        };
+        
+        // Update w/ the result, but removing anything that hasn't been uploaded
+        ctrl._update = function() {
+            var files = ctrl.files.filter(function(file) {
+                    return file.uploaded && file.remote;
+                }).map(function(file) {
+                    return file.remote;
+                });
+            
+            ctrl.options.update(
+                ctrl.options.path,
+                ctrl.options.field.multiple ? files : files[0]
+            );
+        };
+        
+        // Upload any files that haven't been uploaded yet
+        ctrl._upload = function() {
+            var files = ctrl.files.filter(function(file) {
+                    return !file.uploaded && !file.uploading;
+                });
+            
+            if(!files.length) {
+                return;
+            }
+            
+            fetch(ctrl.options.field.ws)
+            .then(checkStatus)
+            .then(function(response) {
+                return response.json();
+            })
+            .then(function(config) {
+                files.forEach(function(file) {
+                    file.uploading = true;
+                });
+                
+                // queue a redraw here so we can show uploading status
                 m.redraw();
                 
-                return ctrl._upload();
-            }
-        );
-    };
-    
-    // Update w/ the result, but removing anything that hasn't been uploaded
-    ctrl._update = function() {
-        var files = ctrl.files.filter(function(file) {
-                return file.uploaded && file.remote;
-            }).map(function(file) {
-                return file.remote;
-            });
-        
-        ctrl.options.update(
-            ctrl.options.path,
-            ctrl.options.field.multiple ? files : files[0]
-        );
-    };
-    
-    // Upload any files that haven't been uploaded yet
-    ctrl._upload = function() {
-        var files = ctrl.files.filter(function(file) {
-                return !file.uploaded && !file.uploading;
-            });
-        
-        if(!files.length) {
-            return;
-        }
-        
-        fetch(ctrl.options.field.ws)
-        .then(checkStatus)
-        .then(function(response) {
-            return response.json();
-        })
-        .then(function(config) {
-            files.forEach(function(file) {
-                file.uploading = true;
-            });
-            
-            // queue a redraw here so we can show uploading status
-            m.redraw();
-            
-            return Promise.all(
-                files.map(function(file) {
-                    var data = new FormData();
-                    
-                    each(config.fields, function(val, key) {
-                        data.append(key, val);
-                    });
-                    
-                    data.append("Content-Type", file.type);
-                    
-                    each(ctrl.options.field.headers || {}, function(value, key) {
-                        data.append(key, value);
-                    });
-                    
-                    data.append(config.filefield, file);
-                    
-                    return fetch(config.action, {
-                        method : "post",
-                        body   : data,
-                        mode   : "cors"
+                return Promise.all(
+                    files.map(function(file) {
+                        var data = new FormData();
+                        
+                        each(config.fields, function(val, key) {
+                            data.append(key, val);
+                        });
+                        
+                        data.append("Content-Type", file.type);
+                        
+                        each(ctrl.options.field.headers || {}, function(value, key) {
+                            data.append(key, value);
+                        });
+                        
+                        data.append(config.filefield, file);
+                        
+                        return fetch(config.action, {
+                            method : "post",
+                            body   : data,
+                            mode   : "cors"
+                        })
+                        .then(function(response) {
+                            if(status(response)) {
+                                file.uploaded  = true;
+                                file.uploading = false;
+                                file.remote    = join(config.action, config.fields.key.replace("${filename}", file.name));
+                            }
+                            
+                            // queue a redraw as each file completes/fails
+                            m.redraw();
+                            
+                            return file;
+                        });
                     })
-                    .then(function(response) {
-                        if(status(response)) {
-                            file.uploaded  = true;
-                            file.uploading = false;
-                            file.remote    = join(config.action, config.fields.key.replace("${filename}", file.name));
-                        }
-                        
-                        // queue a redraw as each file completes/fails
-                        m.redraw();
-                        
-                        return file;
-                    });
-                })
-            );
-        })
-        .then(ctrl._update)
-        .catch(function(error) {
-            // TODO: error-handling
-            console.error(error);
-        });
-    };
-}
+                );
+            })
+            .then(ctrl._update)
+            .catch(function(error) {
+                // TODO: error-handling
+                console.error(error);
+            });
+        };
+    },
 
-export function view(ctrl, options) {
-    var field  = options.field;
-    
-    ctrl.options = options;
+    view : function(ctrl, options) {
+        var field  = options.field;
+        
+        ctrl.options = options;
 
-    return m("div", { class : options.class },
-        label(ctrl, options),
-        m("div", {
-                // Attrs
-                class : css[ctrl.dragging ? "highlight" : "target"],
-                
-                // Events
-                ondragover  : ctrl.dragon,
-                ondragleave : ctrl.dragoff,
-                ondragend   : ctrl.dragoff,
-                ondrop      : ctrl.drop
-            },
-            ctrl.files.length ?
-                m("ul", { class : css.queue },
-                    ctrl.files.map(function(file, idx) {
-                        return m("li", { class : css.queued },
-                            m("div", { class : css.image },
-                                m("img", {
-                                    class : css.img,
-                                    src   : file.remote || file.src
-                                })
-                            ),
-                            m("div", { class : css.meta },
-                                m("p", { class : css.name }, file.name),
-                                file.uploading ?
-                                    m("p", "UPLOADING") :
-                                    null,
-                                file.uploaded ?
-                                    m("input", {
-                                        value   : file.remote,
-                                        onclick : function(e) {
-                                            e.target.select();
-                                        }
-                                    }) :
-                                    null
-                            ),
-                            m("div", { class : css.actions },
-                                m("button", {
-                                        // Attrs
-                                        class : css.remove,
-                                        title : "Remove",
-                                        
-                                        // Events
-                                        onclick : ctrl.remove.bind(ctrl, idx)
-                                    },
-                                    m("svg", { class : css.icon },
-                                        m("use", { href : icons + "#remove" })
+        return m("div", { class : options.class },
+            label(ctrl, options),
+            m("div", {
+                    // Attrs
+                    class : css[ctrl.dragging ? "highlight" : "target"],
+                    
+                    // Events
+                    ondragover  : ctrl.dragon,
+                    ondragleave : ctrl.dragoff,
+                    ondragend   : ctrl.dragoff,
+                    ondrop      : ctrl.drop
+                },
+                ctrl.files.length ?
+                    m("ul", { class : css.queue },
+                        ctrl.files.map(function(file, idx) {
+                            return m("li", { class : css.queued },
+                                m("div", { class : css.image },
+                                    m("img", {
+                                        class : css.img,
+                                        src   : file.remote || file.src
+                                    })
+                                ),
+                                m("div", { class : css.meta },
+                                    m("p", { class : css.name }, file.name),
+                                    file.uploading ?
+                                        m("p", "UPLOADING") :
+                                        null,
+                                    file.uploaded ?
+                                        m("input", {
+                                            value   : file.remote,
+                                            onclick : function(e) {
+                                                e.target.select();
+                                            }
+                                        }) :
+                                        null
+                                ),
+                                m("div", { class : css.actions },
+                                    m("button", {
+                                            // Attrs
+                                            class : css.remove,
+                                            title : "Remove",
+                                            
+                                            // Events
+                                            onclick : ctrl.remove.bind(ctrl, idx)
+                                        },
+                                        m("svg", { class : css.icon },
+                                            m("use", { href : icons + "#remove" })
+                                        )
                                     )
                                 )
-                            )
-                        );
-                    })
-                ) :
-                    
-                m("p", { class : css.instructions }, field.multiple ?
-                    "Drop files here to upload" :
-                    "Drop a file here to upload"
-                )
-        )
-    );
-}
+                            );
+                        })
+                    ) :
+                        
+                    m("p", { class : css.instructions }, field.multiple ?
+                        "Drop files here to upload" :
+                        "Drop a file here to upload"
+                    )
+            )
+        );
+    }
+};


### PR DESCRIPTION
As per @tivac 's request:

Instead of this:
```
// children.js
`import * as something from "./something.js"

// something.js
export function controller() { ... };
export function view() { ... };
```

Convert to this:
```
// children.js
import something from "./something.js"

// something.js
export default {
  controller : function() { ... },
  view : function() { ... }
}
```

