### PR TITLE
Fix schema-edit page and bad schema-edit route.

### DIFF
--- a/src/pages/content-edit/content-edit.css
+++ b/src/pages/content-edit/content-edit.css
@@ -2,12 +2,6 @@
 @value icons_css:   "../../icons.css";
 @value buttons_css: "../../buttons.css";
 
-.content {
-    composes: section from layout_css;
-    position: relative;
-
-    flex: 1 1 100%;
-}
 
 .head {
     composes: head from layout_css;
@@ -72,7 +66,7 @@
 
 /* No item selected */
 .empty {
-    composes: content;
+    composes: content from layout_css;
     
     text-align: center;
     justify-content: center;

--- a/src/pages/content-edit/index.js
+++ b/src/pages/content-edit/index.js
@@ -117,7 +117,6 @@ export function view(ctrl) {
     return m.component(layout, {
         title   : title,
         content : [
-            // m("div", { class : css.content },
             m("div", { class : layout.css.content },
                 m.component(head, ctrl),
                 m("div", { class : css.body },

--- a/src/pages/content-edit/index.js
+++ b/src/pages/content-edit/index.js
@@ -117,7 +117,8 @@ export function view(ctrl) {
     return m.component(layout, {
         title   : title,
         content : [
-            m("div", { class : css.content },
+            // m("div", { class : css.content },
+            m("div", { class : layout.css.content },
                 m.component(head, ctrl),
                 m("div", { class : css.body },
                     m("div", { class : css.contentsContainer },

--- a/src/pages/layout/layout.css
+++ b/src/pages/layout/layout.css
@@ -4,6 +4,19 @@
     height: 100%;
 }
 
+.section {
+    composes: vertical;
+
+    width: 100%;
+}
+
+.content {
+    composes: section;
+    position: relative;
+
+    flex: 1 1 100%;
+}
+
 .contentWidth {
     max-width: 1170px;
     min-width: 720px;
@@ -30,11 +43,6 @@
     min-height: 100%;
 }
 
-.section {
-    composes: vertical;
-
-    width: 100%;
-}
 
 .padding {
     padding: 1em 20px;

--- a/src/pages/schema-edit/index.js
+++ b/src/pages/schema-edit/index.js
@@ -81,7 +81,7 @@ export function view(ctrl) {
     
     return m.component(layout, {
         title   : "Edit - " + capitalize(ctrl.schema.name),
-        content : m("div", { class : layout.css.content },
+        content : m("div", { class : css.content },
             ctrl.error ?
                 m("p", { class : css.error }, ctrl.error) :
                 null,

--- a/src/pages/schema-edit/index.js
+++ b/src/pages/schema-edit/index.js
@@ -81,15 +81,7 @@ export function view(ctrl) {
     
     return m.component(layout, {
         title   : "Edit - " + capitalize(ctrl.schema.name),
-        content : 
-
-
-        // m("div", { class : css.content },
-        //     m.component(head, ctrl),
-        //     m("div", { class : css.body },
-        //         m("div", { class : css.contentsContainer },
-            
-        m("div", { class : layout.css.content },
+        content : m("div", { class : layout.css.content },
             ctrl.error ?
                 m("p", { class : css.error }, ctrl.error) :
                 null,

--- a/src/pages/schema-edit/index.js
+++ b/src/pages/schema-edit/index.js
@@ -81,7 +81,15 @@ export function view(ctrl) {
     
     return m.component(layout, {
         title   : "Edit - " + capitalize(ctrl.schema.name),
-        content : m("div", { class : layout.css.content },
+        content : 
+
+
+        // m("div", { class : css.content },
+        //     m.component(head, ctrl),
+        //     m("div", { class : css.body },
+        //         m("div", { class : css.contentsContainer },
+            
+        m("div", { class : layout.css.content },
             ctrl.error ?
                 m("p", { class : css.error }, ctrl.error) :
                 null,

--- a/src/pages/schema-edit/schema-edit.css
+++ b/src/pages/schema-edit/schema-edit.css
@@ -10,6 +10,12 @@
     padding-bottom: 5em;
 }
 
+.content {
+    composes: content from layout_css;
+
+    padding: 0 0 0 20px;
+}
+
 .meta {
     /* ??? */
 }
@@ -48,7 +54,6 @@
     composes: hbox from flexCss;
     
     flex: 4;
-    overflow-y: auto;
 }
 
 .panes {
@@ -81,6 +86,6 @@
 /* Override codemirror styling to make it expannnnd */
 .editor :global(.CodeMirror) {
     composes: input from "../../form.css";
-    
-    height: 100% !important;
+
+    height: auto;
 }

--- a/src/pages/schema-edit/schema-edit.css
+++ b/src/pages/schema-edit/schema-edit.css
@@ -1,9 +1,13 @@
 @import "../../../node_modules/codemirror/lib/codemirror.css";
 
+@value layout_css:  "../layout/layout.css";
 @value flexCss: "../../flex.css";
 
 .body {
-    composes: body from "../layout/layout.css";
+    composes: body from layout_css;
+    composes: contentWidth from layout_css;
+
+    padding-bottom: 5em;
 }
 
 .meta {

--- a/src/routes/default.js
+++ b/src/routes/default.js
@@ -22,12 +22,14 @@ export default function() {
 
         "/content/new" : auth(schemaNew),
 
+        // Screw it. Support both.
+        "/content/:schema/edit" : auth(schemaEdit),
+        "/listing/:schema/edit" : auth(schemaEdit),
+
         "/content/:schema/:id" : auth(edit),
 
         "/listing/:schema" : auth(listing),
         "/listing/"        : auth(listing),
-        
-        "/listing/:schema/edit" : auth(schemaEdit),
 
         "/..." : {
             view : function() {

--- a/src/routes/default.js
+++ b/src/routes/default.js
@@ -23,15 +23,12 @@ export default function() {
         "/content/new" : auth(schemaNew),
 
         "/content/:schema/:id" : auth(edit),
-        "/content/:schema"     : auth(edit),
 
         "/listing/:schema" : auth(listing),
         "/listing/"        : auth(listing),
-
-        // Screw it, support both.
-        "/content/:schema/edit" : auth(schemaEdit),
-        "/listing/:schema/edit" : auth(schemaEdit),
         
+        "/listing/:schema/edit" : auth(schemaEdit),
+
         "/..." : {
             view : function() {
                 return m("h1", "404");


### PR DESCRIPTION
* Fix schema layout bug:
  * Moved some CSS to `layout` so `schema-edit` can use it too.
  * Touched up `schema-edit` to make it feel a little nicer to use.
* Fix schema routing bug:
  * Strange issue with the order of route definitions. It seems like when you have two similar routes, and one is longer than the other (e.g. more params), the longer of the two should go first so it takes priority if its conditions are met. Otherwise, (unconfirmed, but suspected) it seems that Mithril sees the shorter route as a match and begins to run its code before realizing the longer route is more appropriate. If there another `m.route("/somewhere/")` call triggered in that first destination, it may be triggered before Mithril routing realizes it needs to go to the longer route.

Not sure how well I wrote that up. The short version: Put longer routes first.

[ Fixes #146 ]
