### PR TITLE
Show progress bar on entry listing

### DIFF
--- a/src/pages/content-edit/content-state.js
+++ b/src/pages/content-edit/content-state.js
@@ -2,9 +2,11 @@ import m from "mithril";
 import get from "lodash.get";
 import set from "lodash.set";
 import merge from "lodash.merge";
+import sluggo from "sluggo";
 
 import db from "../../lib/firebase";
 import * as snapshot from "./lib/transformer-snapshot.js";
+import name from "./name.js";
 import Hidden from "./lib/delegator-hidden.js";
 import Schedule from "./lib/delegator-schedule.js";
 import Validity from "./lib/delegator-validity.js";
@@ -101,6 +103,10 @@ Content.prototype = {
     setSchema : function(schema, key) {
         this.state.schema = schema;
         this.state.schema.key = key;
+
+        if(!this.state.meta.name) {
+            this.state.meta.name = name(schema, {});
+        }
     },
 
     registerForm : function(formEl) {
@@ -127,8 +133,9 @@ Content.prototype = {
         m.redraw();
     },
 
-    titleChange : function(name) {
-        this.state.meta.name = name;
+    titleChange : function(entryName) {
+        this.state.meta.name = entryName;
+        this.state.meta.slug = sluggo(entryName);
         this.state.meta.dirty = true;
 
         m.redraw();

--- a/src/pages/content-edit/index.js
+++ b/src/pages/content-edit/index.js
@@ -91,8 +91,8 @@ export function view(ctrl) {
     }
 
     return m.component(layout, {
-        title     : title,
-        content   : [
+        title   : title,
+        content : [
             m("div", { class : layout.css.content },
                 m.component(head,     { content : ctrl.content }),
                 m.component(formView, { content : ctrl.content })

--- a/src/pages/content-edit/index.js
+++ b/src/pages/content-edit/index.js
@@ -78,7 +78,7 @@ export function view(ctrl) {
         title;
 
     if(!state.schema) {
-        return m.component(layout, { progress : true });
+        return m.component(layout, { loading : true });
     }
 
     title = [ get(state.meta, "name"), get(state.schema, "name") ]

--- a/src/pages/content-edit/index.js
+++ b/src/pages/content-edit/index.js
@@ -78,7 +78,7 @@ export function view(ctrl) {
         title;
 
     if(!state.schema) {
-        return m.component(layout);
+        return m.component(layout, { isLoading : true });
     }
 
     title = [ get(state.meta, "name"), get(state.schema, "name") ]
@@ -91,8 +91,8 @@ export function view(ctrl) {
     }
 
     return m.component(layout, {
-        title   : title,
-        content : [
+        title     : title,
+        content   : [
             m("div", { class : layout.css.content },
                 m.component(head,     { content : ctrl.content }),
                 m.component(formView, { content : ctrl.content })

--- a/src/pages/content-edit/index.js
+++ b/src/pages/content-edit/index.js
@@ -78,7 +78,7 @@ export function view(ctrl) {
         title;
 
     if(!state.schema) {
-        return m.component(layout, { isLoading : true });
+        return m.component(layout, { progress : true });
     }
 
     title = [ get(state.meta, "name"), get(state.schema, "name") ]

--- a/src/pages/content-edit/index.js
+++ b/src/pages/content-edit/index.js
@@ -104,7 +104,7 @@ export function view(ctrl) {
         title   : title,
         loading : ctrl.loading,
         content : [
-            m("div", { class   : layout.css.content },
+            m("div", { class : layout.css.content },
                 m.component(head,     { content : ctrl.content }),
                 m.component(formView, { content : ctrl.content })
             )

--- a/src/pages/content-edit/index.js
+++ b/src/pages/content-edit/index.js
@@ -26,6 +26,7 @@ export function controller() {
 
         content;
 
+<<<<<<< f592b0cae7f2c1d056a4f2bb0237c9780c83360b
     // Ensure we have no lingering event listeners.
     schema.off();
     ref.off();
@@ -35,6 +36,14 @@ export function controller() {
     ctrl.form   = null;
     ctrl.data   = {};
     ctrl.hidden = [];
+=======
+    ctrl.id      = id;
+    ctrl.ref     = ref;
+    ctrl.form    = null;
+    ctrl.data    = {};
+    ctrl.hidden  = [];
+    ctrl.loading = true;
+>>>>>>> Add loading to content edit
 
     // New state for every page change.
     ctrl.content = content = new Content();
@@ -46,6 +55,7 @@ export function controller() {
 
     schema.on("value", function(snap) {
         content.setSchema(snap.val(), snap.key());
+        ctrl.loading = false;
 
         m.redraw();
     });
@@ -92,8 +102,9 @@ export function view(ctrl) {
 
     return m.component(layout, {
         title   : title,
+        loading : ctrl.loading,
         content : [
-            m("div", { class : layout.css.content },
+            m("div", { class   : layout.css.content },
                 m.component(head,     { content : ctrl.content }),
                 m.component(formView, { content : ctrl.content })
             )

--- a/src/pages/content-edit/lib/delegator-validity.js
+++ b/src/pages/content-edit/lib/delegator-validity.js
@@ -1,6 +1,8 @@
 import m from "mithril";
 import debounce from "lodash.debounce";
 
+import name from "../name.js";
+
 import css from "../invalid-msg.css";
 
 function reqPrefix(name) {
@@ -102,6 +104,7 @@ Validity.prototype = {
 
         state.form.valid = true;
         state.form.invalidMessages = [];
+        this.content.toggleInvalid(false);
     },
 
     onFormFocus : function() {
@@ -129,6 +132,12 @@ Validity.prototype = {
             state   = this.content.get(),
             isValid = true,
             requiresValid;
+
+        if(state.meta.name === name(state.schema, {})) {
+            // All saves must have a unique name.
+            this.addInvalidMessage("Entry must have a title/name.");
+            isValid = false;
+        }
 
         this.content.schedule.updateStatus();
 

--- a/src/pages/content-edit/name.js
+++ b/src/pages/content-edit/name.js
@@ -1,5 +1,5 @@
 "use strict";
 
 export default function name(schema, data) {
-    return data.name || "Untitled " + schema.name;
+    return data.name || (schema.name && "Untitled " + schema.name) || "...";
 }

--- a/src/pages/layout/index.js
+++ b/src/pages/layout/index.js
@@ -48,7 +48,9 @@ export function view(ctrl, options) {
     document.title = (options.title || "Loading...") + " | " + title;
 
     return m("div", { class : layout.container },
-        options.content ? null : m("div", { class : progress.bar }),
+        options && options.inProgress ?
+            m("div", { class : progress.bar }) :
+            null,
 
         m("div", { class : header.header },
 

--- a/src/pages/layout/index.js
+++ b/src/pages/layout/index.js
@@ -7,7 +7,7 @@ import prefix from "../../lib/prefix";
 
 import header from "./header.css";
 import layout from "./layout.css";
-import progress from "./progress.css";
+import loading from "./loading.css";
 
 // exporting so others can use it more easily
 export { layout as css };
@@ -48,8 +48,8 @@ export function view(ctrl, options) {
     document.title = (options.title || "Loading...") + " | " + title;
 
     return m("div", { class : layout.container },
-        options && options.inProgress ?
-            m("div", { class : progress.bar }) :
+        options && options.loading ?
+            m("div", { class : loading.bar }) :
             null,
 
         m("div", { class : header.header },

--- a/src/pages/layout/loading.css
+++ b/src/pages/layout/loading.css
@@ -21,14 +21,14 @@
 
     background: rgb(66, 184, 221);
 
-    animation: progressBefore 2s linear infinite;
+    animation: loadingBefore 2s linear infinite;
 }
 
 .bar::after {
-    animation-name: progressAfter;
+    animation-name: loadingAfter;
 }
 
-@keyframes progressBefore {
+@keyframes loadingBefore {
     0% {
         left: 0%;
         width: 0%;
@@ -45,7 +45,7 @@
     }
 }
 
-@keyframes progressAfter {
+@keyframes loadingAfter {
     0% {
         left: 0%;
         width: 0%;

--- a/src/pages/listing/index.js
+++ b/src/pages/listing/index.js
@@ -313,9 +313,9 @@ export function view(ctrl) {
     }
 
     return m.component(layout, {
-        title      : get(ctrl, "schema.name") || "...",
+        title   : get(ctrl, "schema.name") || "...",
         loading : ctrl.loading,
-        content    : [
+        content : [
             m("div", { class : layout.css.content },
                 m("div", { class : css.contentHd },
                     m("button", {

--- a/src/pages/listing/index.js
+++ b/src/pages/listing/index.js
@@ -301,7 +301,7 @@ export function controller() {
 
 
 export function view(ctrl) {
-    var content = ctrl.results || ctrl.content || [],
+    var content = ctrl.results || ctrl.content,
         locked  = config.locked,
         isSearchResults = Boolean(ctrl.results);
 
@@ -311,7 +311,7 @@ export function view(ctrl) {
 
     return m.component(layout, {
         title   : get(ctrl, "schema.name") || "...",
-        content : [
+        content : !content ? null : [
 
             m("div", { class : layout.css.content },
                 m("div", { class : css.contentHd },
@@ -507,7 +507,7 @@ export function view(ctrl) {
                                                             m("use", { href : icons + "#preview" })
                                                         )
                                                     ) :
-                                                null
+                                                    null
                                             )
                                         )
                                     );

--- a/src/pages/listing/index.js
+++ b/src/pages/listing/index.js
@@ -60,10 +60,12 @@ export function controller() {
     ctrl.results = null;
 
     ctrl.contentLoc = null;
-    ctrl.queryRef = null;
+    ctrl.queryRef   = null;
 
     ctrl.searchInput = null;
-    ctrl.searchMode = SEARCH_MODE_RECENT;
+    ctrl.searchMode  = SEARCH_MODE_RECENT;
+
+    ctrl.inProgress = true;
 
     // We need to check for an "overflowItem" to peek at
     // the next page's first item. This lets us grab the
@@ -118,6 +120,7 @@ export function controller() {
 
         ctrl.schema = snap.val();
         ctrl.schema.key = snap.key();
+        ctrl.inProgress = false;
 
         ctrl.contentLoc = db.child("content/" + ctrl.schema.key);
         ctrl.showPage();
@@ -301,7 +304,7 @@ export function controller() {
 
 
 export function view(ctrl) {
-    var content = ctrl.results || ctrl.content,
+    var content = ctrl.results || ctrl.content || [],
         locked  = config.locked,
         isSearchResults = Boolean(ctrl.results);
 
@@ -310,9 +313,9 @@ export function view(ctrl) {
     }
 
     return m.component(layout, {
-        title   : get(ctrl, "schema.name") || "...",
-        content : !content ? null : [
-
+        title     : get(ctrl, "schema.name") || "...",
+        inProgress : ctrl.inProgress,
+        content   : [
             m("div", { class : layout.css.content },
                 m("div", { class : css.contentHd },
                     m("button", {

--- a/src/pages/listing/index.js
+++ b/src/pages/listing/index.js
@@ -313,9 +313,9 @@ export function view(ctrl) {
     }
 
     return m.component(layout, {
-        title     : get(ctrl, "schema.name") || "...",
+        title      : get(ctrl, "schema.name") || "...",
         inProgress : ctrl.inProgress,
-        content   : [
+        content    : [
             m("div", { class : layout.css.content },
                 m("div", { class : css.contentHd },
                     m("button", {

--- a/src/pages/listing/index.js
+++ b/src/pages/listing/index.js
@@ -65,7 +65,7 @@ export function controller() {
     ctrl.searchInput = null;
     ctrl.searchMode  = SEARCH_MODE_RECENT;
 
-    ctrl.inProgress = true;
+    ctrl.loading = true;
 
     // We need to check for an "overflowItem" to peek at
     // the next page's first item. This lets us grab the
@@ -120,7 +120,7 @@ export function controller() {
 
         ctrl.schema = snap.val();
         ctrl.schema.key = snap.key();
-        ctrl.inProgress = false;
+        ctrl.loading = false;
 
         ctrl.contentLoc = db.child("content/" + ctrl.schema.key);
         ctrl.showPage();
@@ -314,7 +314,7 @@ export function view(ctrl) {
 
     return m.component(layout, {
         title      : get(ctrl, "schema.name") || "...",
-        inProgress : ctrl.inProgress,
+        loading : ctrl.loading,
         content    : [
             m("div", { class : layout.css.content },
                 m("div", { class : css.contentHd },

--- a/src/pages/listing/index.js
+++ b/src/pages/listing/index.js
@@ -208,6 +208,8 @@ export function controller() {
             .child(ctrl.schema.key)
             .child(data.key);
 
+        ref.off(); // Ensure we don't have lingering listeners.
+
         if(window.confirm("Remove " + data.name + "?")) {
             ref.remove().catch(console.error.bind(console));
         }

--- a/src/pages/schema-edit/index.js
+++ b/src/pages/schema-edit/index.js
@@ -81,7 +81,7 @@ export function view(ctrl) {
         state   = content.get();
 
     if(!ctrl.schema) {
-        return m.component(layout);
+        return m.component(layout, { inProgress : true });
     }
 
     return m.component(layout, {

--- a/src/pages/schema-edit/index.js
+++ b/src/pages/schema-edit/index.js
@@ -81,7 +81,7 @@ export function view(ctrl) {
         state   = content.get();
 
     if(!ctrl.schema) {
-        return m.component(layout, { inProgress : true });
+        return m.component(layout, { loading : true });
     }
 
     return m.component(layout, {


### PR DESCRIPTION
Two things with this:
1. The contentHd/pagination won't show until listing is loaded.  
   - `layout` component could take 2 children: `contentHd` and `contentBd`
   - `layout` component could look for a `loading` flag
   - components could render the progress bar themselves
2. Stylistically what do you think about `!condition ? null : m("div")` vs `condition ? m("div") : null`? Reminds me of the early out approach, also no dangling `null`s.
