### PR TITLE
Better loading state

### DIFF
--- a/src/pages/content-edit/index.js
+++ b/src/pages/content-edit/index.js
@@ -47,7 +47,6 @@ export function controller() {
 
     schema.on("value", function(snap) {
         content.setSchema(snap.val(), snap.key());
-        ctrl.loading = false;
 
         m.redraw();
     });
@@ -68,7 +67,9 @@ export function controller() {
         ctrl.data = assign(data, {
             fields : merge(data.fields, state.fields)
         });
-        
+
+        ctrl.loading = false;
+
         return m.redraw();
     });
 

--- a/src/pages/listing/index.js
+++ b/src/pages/listing/index.js
@@ -109,6 +109,8 @@ export function controller() {
             onNext.call(this, snap);
         }
 
+        ctrl.loading = false;
+
         m.redraw();
     }
 
@@ -120,9 +122,8 @@ export function controller() {
 
         ctrl.schema = snap.val();
         ctrl.schema.key = snap.key();
-        ctrl.loading = false;
-
         ctrl.contentLoc = db.child("content/" + ctrl.schema.key);
+
         ctrl.showPage();
     }
 


### PR DESCRIPTION
Set `ctrl.loading` to `false` a little later on the content edit and listing page.

Sorry for the quality and completeness of these PRs!